### PR TITLE
Fix PHP 8.1 deprecation warnings

### DIFF
--- a/src/Markup.php
+++ b/src/Markup.php
@@ -35,7 +35,7 @@ class Markup implements \Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return \function_exists('mb_get_info') ? mb_strlen($this->content, $this->charset) : \strlen($this->content);
     }

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -12,6 +12,7 @@
 
 namespace Twig\Node;
 
+use Traversable;
 use Twig\Compiler;
 use Twig\Source;
 
@@ -210,15 +211,15 @@ class Node implements \Twig_NodeInterface
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return \count($this->nodes);
     }
 
     /**
-     * @return \Traversable
+     * @return Traversable
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->nodes);
     }

--- a/src/Util/TemplateDirIterator.php
+++ b/src/Util/TemplateDirIterator.php
@@ -16,12 +16,12 @@ namespace Twig\Util;
  */
 class TemplateDirIterator extends \IteratorIterator
 {
-    public function current()
+    public function current(): mixed
     {
         return file_get_contents(parent::current());
     }
 
-    public function key()
+    public function key(): string
     {
         return (string) parent::key();
     }


### PR DESCRIPTION
## What
Fix PHP 8.1 deprecation warnings, e.g.:

```
Deprecated: Return type of Twig\Node\Node::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in twig/twig/src/Node/Node.php on line 213
Deprecated: Return type of Twig\Node\Node::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in twig/twig/src/Node/Node.php on line 221
```

## Why
To fix deprecation warnings on PHP 8.1

ping @bigcommerce/php