### PR TITLE
Fix deprecation warning when creating ReflectionMethod on PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {

--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -302,7 +302,7 @@ abstract class CallExpression extends AbstractExpression
                 // __staticCall()
                 return [null, []];
             }
-            $r = new \ReflectionMethod($callable);
+            $r = \ReflectionMethod::createFromMethodName($callable);
             $callable = [$class, $method];
         } else {
             $r = new \ReflectionFunction($callable);


### PR DESCRIPTION
Fix deprecation warning when creating ReflectionMethod on PHP 8.4

Fixes:

```
src/Node/Expression/CallExpression.php:305
Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead
```